### PR TITLE
(bugfix) fix username parsing with spaces in it

### DIFF
--- a/main.js
+++ b/main.js
@@ -135,7 +135,12 @@ client.on("message", async message => {
     var contentleng = message.content.split(' ').length;
     //if message contains a second parameter
     if (contentleng > 1) {
-      var username_ = message.content.split(' ')[1].toLowerCase();
+      var str_list = message.content.split(' ')
+      str_list.shift()
+      if (str_list[str_list.length-1] == "here"){
+        str_list.splice(-1,1)
+      }
+      var username_ = str_list.join(" ").toLowerCase();
       //fetch user in guild by username
       var userlist = await message.guild.members.fetch({});
       for (var uobj of userlist) {


### PR DESCRIPTION
This PR fixes the following scenario:

Lets say you have a friend with a displayname like "Morning Glory Enjoyer".
So to link the bot with him, you do:
```
!link Morning Glory Enjoyer here
```

This will give you the following error message:

```
[ERROR]: A user by the query term Morning could not be found in your channel
```

My approach takes the entire array, removes the first and last (if the last item is "here") item and passes the entire array as username.
This effectively fixes the username parsing.

Im not a node dev, so theres probably a better / cooler way to do this